### PR TITLE
Feat/3 페이지 및 라우팅 설정

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,9 +1,21 @@
-import FetchTest from "./components/FetchTest";
+import { Route, Routes } from "react-router-dom";
+import Main from "./pages/Main";
+import Detail from "./pages/Detail";
+import Favorites from "./pages/Favorites";
+import Search from "./pages/Search";
 
 export default function App() {
   return (
     <>
-      <FetchTest />
+      <header>1세대 포켓몬 도감</header>
+      <main>
+        <Routes>
+          <Route path="/" element={<Main />} />
+          <Route path="/detail/:id" element={<Detail />} />
+          <Route path="/search" element={<Search />} />
+          <Route path="/favorites" element={<Favorites />} />
+        </Routes>
+      </main>
     </>
   );
 }

--- a/src/components/FetchTest.jsx
+++ b/src/components/FetchTest.jsx
@@ -1,3 +1,5 @@
+// 데이터 페치 테스트용 컴포넌트로, 서비스 화면에 노출되지 아니함
+
 import { useEffect } from "react";
 import PokemonDataStore from "../stores/PokemonDataStore";
 

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,5 +1,10 @@
 import { createRoot } from "react-dom/client";
 import "./index.css";
 import App from "./App.jsx";
+import { BrowserRouter } from "react-router-dom";
 
-createRoot(document.getElementById("root")).render(<App />);
+createRoot(document.getElementById("root")).render(
+  <BrowserRouter>
+    <App />
+  </BrowserRouter>
+);

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,3 +1,3 @@
-export default function Datail() {
-  return <div>Datail</div>;
+export default function Detail() {
+  return <div>Detail</div>;
 }

--- a/src/pages/Detail.jsx
+++ b/src/pages/Detail.jsx
@@ -1,0 +1,3 @@
+export default function Datail() {
+  return <div>Datail</div>;
+}

--- a/src/pages/Favorites.jsx
+++ b/src/pages/Favorites.jsx
@@ -1,0 +1,3 @@
+export default function Favorites() {
+  return <div>Favorites</div>;
+}

--- a/src/pages/Main.jsx
+++ b/src/pages/Main.jsx
@@ -1,0 +1,3 @@
+export default function Main() {
+  return <div>Main</div>;
+}

--- a/src/pages/Search.jsx
+++ b/src/pages/Search.jsx
@@ -1,0 +1,3 @@
+export default function Search() {
+  return <div>Search</div>;
+}


### PR DESCRIPTION
1. 페이지 폴더 생성
- pages 폴더를 생성하고, 다음 페이지 컴포넌트를 생성합니다:
Main: 포켓몬 정보 카드를 표시합니다.
Detail: 선택된 포켓몬의 상세 정보를 표시합니다.
Search: 검색 기능을 위한 페이지 컴포넌트를 생성합니다.
Favorites: 찜목록 기능을 위한 페이지 컴포넌트를 생성합니다.

2. 라우팅 설정
- routes와 Route 컴포넌트를 사용하여 애플리케이션의 페이지 라우팅을 설정합니다.